### PR TITLE
Fix localization typing errors caused by renaming of the localization messages folder

### DIFF
--- a/examples/nextjs-app-router-localization-starter/global.d.ts
+++ b/examples/nextjs-app-router-localization-starter/global.d.ts
@@ -1,3 +1,8 @@
-// Use type safe message keys with `next-intl`
-type Messages = typeof import('./localized-microcopy/en.json');
-declare interface IntlMessages extends Messages {}
+import en from "./messages/en.json";
+
+type Messages = typeof en;
+
+declare global {
+  // Use type safe message keys with `next-intl`
+  interface IntlMessages extends Messages {}
+}


### PR DESCRIPTION
Fix localization typing errors caused by renaming of the localization messages folder