### PR TITLE
Update uniform.config.ts - Disable locales since it's empty

### DIFF
--- a/examples/nextjs-app-router-v2/uniform.config.ts
+++ b/examples/nextjs-app-router-v2/uniform.config.ts
@@ -1,3 +1,3 @@
 import { uniformConfig } from "@uniformdev/cli/config";
 
-module.exports = uniformConfig({ preset: "all", disableEntities: ["webhook", "policyDocument"] });
+module.exports = uniformConfig({ preset: "all", disableEntities: ["webhook", "policyDocument", "locale"] });


### PR DESCRIPTION
The npm run uniform:push on an empty project and a fresh code pull gives an error about locales, since there are no locales in the codebase but now Uniform always sets a default locale of en-US. Excluding locales in the Uniform config allows the CLI push command to run successfully.

Error: Error: Sync source (files in uniform-data/locale) is empty and mode is mirror. This would cause deletion of everything in the target (Uniform API), and most likely indicates an error in source definition.