### PR TITLE
fix(nextjs-starter): require higher version of node from netlify

### DIFF
--- a/examples/nextjs-starter/next-env.d.ts
+++ b/examples/nextjs-starter/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/nextjs-starter/next.config.js
+++ b/examples/nextjs-starter/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   images: {
     remotePatterns: [{ protocol: "https", hostname: "*" }],
   },
+  // Next 16 Turbopack + Pages API can omit next-server runtimes from the
+  // preview lambda; force-include them so /api/preview stays runnable.
+  bundlePagesRouterDependencies: true,
 };
 
 module.exports = nextConfig;

--- a/examples/nextjs-starter/package-lock.json
+++ b/examples/nextjs-starter/package-lock.json
@@ -15,17 +15,20 @@
         "@uniformdev/context-next": "20.64.0",
         "@uniformdev/context-react": "20.64.0",
         "@uniformdev/project-map": "20.64.0",
-        "next": "^16.2.6",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
+        "next": "16.2.6",
+        "react": "19.2.6",
+        "react-dom": "19.2.6"
       },
       "devDependencies": {
-        "@types/node": "^18.6.2",
+        "@types/node": "^20.9.0",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "@uniformdev/cli": "20.64.0",
         "npm-run-all": "^4.1.5",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1580,13 +1583,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -6088,9 +6091,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/nextjs-starter/package.json
+++ b/examples/nextjs-starter/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "dev": "run-s uniform:manifest next:dev",
     "start": "next start",
-    "next:dev": "next dev --webpack",
+    "next:dev": "next dev",
     "build": "run-s uniform:manifest next:build",
-    "next:build": "next build --webpack",
+    "next:build": "next build",
     "uniform:manifest": "uniform context manifest download --output ./lib/uniform/contextManifest.json",
     "uniform:pull": "uniform sync pull",
     "uniform:push": "uniform sync push",
@@ -24,9 +24,9 @@
     "@uniformdev/context-next": "20.64.0",
     "@uniformdev/context-react": "20.64.0",
     "@uniformdev/project-map": "20.64.0",
-    "next": "^16.2.6",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "next": "16.2.6",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",

--- a/examples/nextjs-starter/package.json
+++ b/examples/nextjs-starter/package.json
@@ -2,12 +2,15 @@
   "name": "@uniformdev/nextjs-starter",
   "version": "20.64.0",
   "private": true,
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "dev": "run-s uniform:manifest next:dev",
     "start": "next start",
-    "next:dev": "next dev",
+    "next:dev": "next dev --webpack",
     "build": "run-s uniform:manifest next:build",
-    "next:build": "next build",
+    "next:build": "next build --webpack",
     "uniform:manifest": "uniform context manifest download --output ./lib/uniform/contextManifest.json",
     "uniform:pull": "uniform sync pull",
     "uniform:push": "uniform sync push",
@@ -26,7 +29,7 @@
     "react-dom": "^19.2.6"
   },
   "devDependencies": {
-    "@types/node": "^18.6.2",
+    "@types/node": "^20.9.0",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@uniformdev/cli": "20.64.0",


### PR DESCRIPTION
require higher minimal version of node to avoid some random fails on system with nodejs setup (netlify had node 16 :/)
And also added https://nextjs.org/docs/pages/api-reference/config/next-config-js/bundlePagesRouterDependencies parameter to page router next16 starter to fix 5xx errors  from /api/preview on vercel